### PR TITLE
fix: Improve email regex

### DIFF
--- a/src/utils/validateValue.ts
+++ b/src/utils/validateValue.ts
@@ -1,5 +1,6 @@
 const DEFAULT_PATTERN = /\w+/
-const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,3}$/
+// https://html.spec.whatwg.org/#valid-e-mail-address
+const EMAIL_PATTERN = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
 const PW_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{6,}$/
 // const PW_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[#$^+=!*()@%&]).{10,}$/
 // NOTE: At least one lower case English letter, (?=.*?[a-z])


### PR DESCRIPTION
Use the Regex provided by the official [HTML spec for input[type="email"]](https://html.spec.whatwg.org/#valid-e-mail-address) to validate email addresses.

Resolves #23 
