### PR TITLE
🐛 Fix broken CI workflow conditions and add coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         run: pnpm install
 
       - name: Lint
-        if: ${{ hashFiles('biome.json') != '' }}
+        if: hashFiles('biome.json') != ''
         run: pnpm check
 
       - name: Build
         run: pnpm build
 
-      - name: Test
-        run: pnpm test
+      - name: Test & Coverage
+        run: pnpm rapid-form:test:coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm build
 
       - name: Publish 🚀 PRERELEASE
-        if: 'github.event.release.prerelease'
+        if: ${{ github.event.release.prerelease }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           pnpm -r publish --tag next --no-git-checks --access public
@@ -38,7 +38,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish 🚀 PRODUCTION
-        if: '!github.event.release.prerelease'
+        if: ${{ !github.event.release.prerelease }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           pnpm -r publish --no-git-checks --access public


### PR DESCRIPTION
## Summary

- `publish.yml`: `if: 'github.event.release.prerelease'` was a string literal — always truthy, so both prerelease and production publish steps ran on every release. Fixed to proper expressions `${{ github.event.release.prerelease }}` / `${{ !github.event.release.prerelease }}`
- `ci.yml`: cleaned up `if: ${{ ... }}` lint condition syntax; replaced `pnpm test` with `pnpm rapid-form:test:coverage` to get coverage output on every CI run

Closes #55