### PR TITLE
🐛 Fix all CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
   push:
     branches: [ main ]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
   pages: write
@@ -17,13 +14,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout your repository using git
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: Install, build, and upload your site
+      - name: Build and upload site
         uses: withastro/action@v3
         with:
           path: ./packages/docs
           package-manager: pnpm@latest
+          node-version: "22"
 
   deploy:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Node 🧰
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: "22"
           cache: pnpm
 
       - name: Install 📦

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -23,13 +21,14 @@
     }
   },
   "files": {
-    "ignore": [
-      "node_modules",
-      "dist",
-      "coverage",
-      "packages/docs/dist",
-      "packages/docs/.astro",
-      "pnpm-lock.yaml"
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/coverage",
+      "!**/packages/docs/dist",
+      "!**/packages/docs/.astro",
+      "!**/pnpm-lock.yaml"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "rapid-form:watch": "pnpm --filter rapid-form build:watch"
   },
   "devDependencies": {
-    "@biomejs/biome": "latest",
+    "@biomejs/biome": "2.4.12",
     "husky": "^9.1.7",
     "lerna": "^9.0.7",
     "typescript": "^6.0.2"

--- a/packages/rapid-form/specs/utils/FormComponent.tsx
+++ b/packages/rapid-form/specs/utils/FormComponent.tsx
@@ -1,27 +1,59 @@
-import { useRapidForm } from '../../src/index.js'
-import { type ValidationProps } from '../../src/validation.js'
+import { useRapidForm } from '../../src/index.js';
+import type { ValidationProps } from '../../src/validation.js';
 
 export interface ElementType {
-  as: 'input' | 'select' | 'textarea'
-  name: string
-  type?: JSX.IntrinsicElements['input']['type'] | undefined
-  required?: boolean
-  options?: { label: string, value: string }[]
+  as: 'input' | 'select' | 'textarea';
+  name: string;
+  type?: JSX.IntrinsicElements['input']['type'] | undefined;
+  required?: boolean;
+  options?: { label: string; value: string }[];
 }
 
 interface FormProps {
-  elements: ElementType[]
-  config?: ValidationProps['config']
+  elements: ElementType[];
+  config?: ValidationProps['config'];
 }
 
 export function Form({ elements, config }: FormProps): JSX.Element {
-  const { refValidation, errors } = useRapidForm()
-  const components = elements.map((element, key) => {
+  const { refValidation, errors } = useRapidForm();
+  const components = elements.map((element) => {
     switch (element.as) {
-      case 'input':
+      case 'textarea':
+        return (
+          <div key={element.name}>
+            <textarea
+              name={element.name}
+              data-testid={element.name}
+              required={element.required}
+            />
+            <span data-testid={`${element.name}-error`}>
+              {errors[element.name]?.message}
+            </span>
+          </div>
+        );
+      case 'select':
+        return (
+          <div key={element.name}>
+            <select
+              title={element.name}
+              name={element.name}
+              data-testid={element.name}
+              required={element.required}
+            >
+              {element.options?.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <span data-testid={`${element.name}-error`}>
+              {errors[element.name]?.message}
+            </span>
+          </div>
+        );
       default:
         return (
-          <div key={key}>
+          <div key={element.name}>
             <input
               name={element.name}
               type={element.type}
@@ -32,50 +64,19 @@ export function Form({ elements, config }: FormProps): JSX.Element {
               {errors[element.name]?.message}
             </span>
           </div>
-        )
-      case 'textarea':
-        return (
-          <div key={key}>
-            <textarea
-              name={element.name}
-              data-testid={element.name}
-              required={element.required}
-            />
-            <span data-testid={`${element.name}-error`}>
-              {errors[element.name]?.message}
-            </span>
-          </div>
-        )
-      case 'select':
-        return (
-          <div key={key}>
-            <select
-              title={element.name}
-              name={element.name}
-              data-testid={element.name}
-              required={element.required}
-            >
-              {element.options?.map((option, key) => (
-                <option key={key} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-            <span data-testid={`${element.name}-error`}>
-              {errors[element.name]?.message}
-            </span>
-          </div>
-        )
+        );
     }
-  })
+  });
   return (
     <form
       ref={(ref) => {
-        refValidation(ref, config)
+        refValidation(ref, config);
       }}
     >
       {components}
-      <button data-testid="submit-button" type="submit">Submit</button>
+      <button data-testid="submit-button" type="submit">
+        Submit
+      </button>
     </form>
-  )
+  );
 }

--- a/packages/rapid-form/src/reducer.ts
+++ b/packages/rapid-form/src/reducer.ts
@@ -1,41 +1,41 @@
-import { type Reducer } from 'react'
+import type { Reducer } from 'react';
 
 /**
  * Represents a value with a name and a corresponding string value.
  */
 interface Value {
-  name: string
-  value: string
+  name: string;
+  value: string;
 }
 
 /**
  * Represents an error associated with a value.
  */
 interface Error extends Value {
-  isInvalid: boolean
-  errorType?: 'invalidFormat'
-  message?: string
+  isInvalid: boolean;
+  errorType?: 'invalidFormat';
+  message?: string;
 }
 
 /**
  * Represents the state of the reducer.
  */
 export interface State {
-  values: Record<string, Value>
-  errors: Record<string, Error>
-  numberOfRequiredFields: number
+  values: Record<string, Value>;
+  errors: Record<string, Error>;
+  numberOfRequiredFields: number;
 }
 
 /**
  * Represents the type of action that can be dispatched to the reducer.
  */
-type ActionType = 'setValue' | 'setError' | 'reset'
+type ActionType = 'setValue' | 'setError' | 'reset';
 
 /**
  * Represents an action that can be dispatched to the reducer.
  */
 export interface Action extends State {
-  type: ActionType
+  type: ActionType;
 }
 
 /**
@@ -45,15 +45,20 @@ export const initialState: State = {
   values: {},
   errors: {},
   numberOfRequiredFields: 0
-}
+};
 
+// biome-ignore lint/suspicious/noExplicitAny: required for recursive deep merge
 type AnyObject = { [key: string]: any };
 
+// biome-ignore lint/suspicious/noExplicitAny: required for recursive deep merge
 function isObject(item: any): item is AnyObject {
   return item && typeof item === 'object' && !Array.isArray(item);
 }
 
-function deepMerge<T extends AnyObject, U extends AnyObject>(target: T, source: U): T & U {
+function deepMerge<T extends AnyObject, U extends AnyObject>(
+  target: T,
+  source: U
+): T & U {
   const output = { ...target } as T & U;
 
   for (const [key, sourceValue] of Object.entries(source)) {
@@ -74,14 +79,18 @@ function deepMerge<T extends AnyObject, U extends AnyObject>(target: T, source: 
  * @param action The action to be dispatched.
  * @returns The new state after applying the action.
  */
-export const reducer: Reducer<State, Action> = (state, { type, ...data}) => {
+export const reducer: Reducer<State, Action> = (state, { type, ...data }) => {
   switch (type) {
     case 'setValue':
     case 'setError':
-      return deepMerge(state, data)
+      return deepMerge(state, data);
     case 'reset':
-      return { values: data.values, errors: {}, numberOfRequiredFields: data.numberOfRequiredFields }
+      return {
+        values: data.values,
+        errors: {},
+        numberOfRequiredFields: data.numberOfRequiredFields
+      };
   }
-}
+};
 
-export default reducer
+export default reducer;

--- a/packages/rapid-form/tsup.config.ts
+++ b/packages/rapid-form/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsup'
+import { defineConfig } from 'tsup';
 
-const env = process.env['NODE_ENV']
+const env = process.env.NODE_ENV;
 
 export default defineConfig(() => ({
   treeshake: true,
@@ -12,5 +12,5 @@ export default defineConfig(() => ({
   bundle: true,
   watch: env === 'development',
   target: 'es2020',
-  entry: ['src/index.ts'],
-}))
+  entry: ['src/index.ts']
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: latest
+        specifier: 2.4.12
         version: 2.4.12
       husky:
         specifier: ^9.1.7
@@ -6320,7 +6320,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.25.0
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0


### PR DESCRIPTION
## Summary

- `biome.json`: migrate schema v1.9.4 → v2.4.12 (`organizeImports` → `assist.actions`, `files.ignore` → `files.includes`)
- `package.json`: pin `@biomejs/biome` at `2.4.12` to prevent future schema drift
- `ci.yml` / `publish.yml`: `node-version: lts/*` → `"22"` (Astro requires ≥22.12.0)
- `deploy.yml`: add `node-version: "22"` to `withastro/action`
- `tsup.config.ts`: `process.env['NODE_ENV']` → `process.env.NODE_ENV` (biome lint fix)
- `FormComponent.tsx`: move `default` clause last, use `element.name` / `option.value` as keys
- `reducer.ts`: `biome-ignore` for intentional `any` in deep merge utility

Closes #55