### PR TITLE
🐛 Fix badges not rendering on docs homepage

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -22,11 +22,19 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-<div style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;margin-bottom:2rem">
-  [![npm version](https://img.shields.io/npm/v/rapid-form?style=flat-square&color=7C3AED)](https://www.npmjs.com/package/rapid-form)
-  [![npm downloads](https://img.shields.io/npm/dm/rapid-form?style=flat-square&color=7C3AED)](https://www.npmjs.com/package/rapid-form)
-  [![GitHub stars](https://img.shields.io/github/stars/Randagio13/rapid-form?style=flat-square&color=7C3AED)](https://github.com/Randagio13/rapid-form/stargazers)
-  [![license](https://img.shields.io/npm/l/rapid-form?style=flat-square&color=7C3AED)](https://github.com/Randagio13/rapid-form/blob/main/LICENSE)
+<div style={{ display: 'flex', gap: '10px', justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap', marginBottom: '2rem' }}>
+  <a href="https://www.npmjs.com/package/rapid-form" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/npm/v/rapid-form?style=flat-square&color=7C3AED" alt="npm version" />
+  </a>
+  <a href="https://www.npmjs.com/package/rapid-form" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/npm/dm/rapid-form?style=flat-square&color=7C3AED" alt="npm downloads" />
+  </a>
+  <a href="https://github.com/Randagio13/rapid-form/stargazers" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/github/stars/Randagio13/rapid-form?style=flat-square&color=7C3AED" alt="GitHub stars" />
+  </a>
+  <a href="https://github.com/Randagio13/rapid-form/blob/main/LICENSE" target="_blank" rel="noopener">
+    <img src="https://img.shields.io/npm/l/rapid-form?style=flat-square&color=7C3AED" alt="license" />
+  </a>
 </div>
 
 ## See it in action


### PR DESCRIPTION
Markdown image syntax `[![alt](src)](href)` inside JSX `<div>` is never parsed by MDX — only JSX is processed inside JSX elements. Replaced with proper `<a><img /></a>` JSX tags. All 4 badges (version, downloads, stars, license) now render correctly.