### PR TITLE
docs: update docs and README with dynamic fields and security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ No `register()`. No re-renders. Schema validation optional.
 | Re-renders on input | **No** | Yes |
 | Native HTML validation | **Yes** | Partial |
 | Schema validation | **Zod / Yup / any** | Zod / Yup / any |
+| Dynamic fields | **Yes** | Yes |
 
 Point a `ref` at your form. Done.
 
@@ -108,6 +109,26 @@ refValidation(ref, { resolver: zodResolver(schema) });
 ```
 
 A `yupResolver` is also available at `rapid-form/resolvers/yup`. Both adapters are tree-shakeable and add zero runtime dependencies to the core package.
+
+## Dynamic fields
+
+Conditional fields and field arrays are tracked automatically — no extra setup needed.
+
+```tsx
+function ConditionalForm() {
+  const [showExtra, setShowExtra] = useState(false);
+  const { refValidation, errors } = useRapidForm();
+
+  return (
+    <form ref={(ref) => refValidation(ref)}>
+      <input type="checkbox" name="agree" required onChange={(e) => setShowExtra(e.target.checked)} />
+      {showExtra && <input type="text" name="extra" required />}
+      {errors.extra?.isInvalid && <span>{errors.extra.message}</span>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
 
 ## Read values
 

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
             { label: 'Customization', slug: 'guides/customization' },
             { label: 'Custom Validation', slug: 'guides/custom-validation' },
             { label: 'Schema Validation', slug: 'guides/schema-validation' },
+            { label: 'Dynamic Fields', slug: 'guides/dynamic-fields' },
             { label: 'TypeScript', slug: 'guides/typescript' },
             { label: 'Styling Errors', slug: 'guides/styling-errors' }
           ]

--- a/packages/docs/src/content/docs/guides/dynamic-fields.mdx
+++ b/packages/docs/src/content/docs/guides/dynamic-fields.mdx
@@ -1,0 +1,152 @@
+---
+title: Dynamic Fields
+description: Fields added or removed at runtime are automatically tracked by Rapid Form — no extra setup required.
+---
+
+Rapid Form automatically tracks fields that are added or removed after the initial render. Whether you are showing a field conditionally or managing a list of rows, errors and values for removed fields are cleaned up without any additional code.
+
+:::tip
+The standard `useRapidForm` hook and an inline `ref` callback on `<form>` are all you need. There is no special dynamic-fields API.
+:::
+
+---
+
+## Conditional fields
+
+Use a boolean state value to mount or unmount a field. When the field disappears from the DOM, Rapid Form removes its entry from both `errors` and `values` automatically.
+
+```tsx
+import { useState } from 'react';
+import { useRapidForm } from 'rapid-form';
+
+export function ConditionalFieldForm() {
+  const { refValidation, errors } = useRapidForm();
+  const [showPhone, setShowPhone] = useState(false);
+
+  return (
+    <form ref={(ref) => refValidation(ref, { validations: {
+      email: { required: true, type: 'email' },
+      phone: { required: true },
+    }})}>
+      <label>
+        <input type="email" name="email" placeholder="Email" />
+        {errors['email']?.isInvalid && <span>{errors['email'].message}</span>}
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={showPhone}
+          onChange={(e) => setShowPhone(e.target.checked)}
+        />
+        {' '}Add phone number
+      </label>
+
+      {showPhone && (
+        <label>
+          <input type="tel" name="phone" placeholder="Phone" />
+          {errors['phone']?.isInvalid && <span>{errors['phone'].message}</span>}
+        </label>
+      )}
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+When the checkbox is unchecked, the `phone` field unmounts. Rapid Form detects the removal and clears `errors['phone']` and `values['phone']` — the error span disappears along with the field.
+
+:::note
+Validation rules listed under `validations` for a field that is not currently mounted are never triggered. You can safely keep the full validation config in one place.
+:::
+
+---
+
+## Field arrays
+
+A field array is a dynamic list of rows where each row contains one or more inputs. Use an array in state to drive the list, and give each input a unique name (e.g. `email.0`, `email.1`). When a row is removed, Rapid Form cleans up the corresponding errors and values.
+
+```tsx
+import { useState } from 'react';
+import { useRapidForm } from 'rapid-form';
+
+type Row = { id: number };
+
+let nextId = 2;
+
+export function EmailListForm() {
+  const { refValidation, errors } = useRapidForm();
+  const [rows, setRows] = useState<Row[]>([{ id: 1 }]);
+
+  const addRow = () => setRows((prev) => [...prev, { id: nextId++ }]);
+
+  const removeRow = (id: number) =>
+    setRows((prev) => prev.filter((r) => r.id !== id));
+
+  // Build validations dynamically for however many rows exist
+  const validations = Object.fromEntries(
+    rows.map((_, i) => [`email.${i}`, { required: true, type: 'email' as const }])
+  );
+
+  return (
+    <form ref={(ref) => refValidation(ref, { validations })}>
+      {rows.map((row, i) => (
+        <div key={row.id}>
+          <input
+            type="email"
+            name={`email.${i}`}
+            placeholder={`Email ${i + 1}`}
+          />
+          {errors[`email.${i}`]?.isInvalid && (
+            <span>{errors[`email.${i}`].message}</span>
+          )}
+          {rows.length > 1 && (
+            <button type="button" onClick={() => removeRow(row.id)}>
+              Remove
+            </button>
+          )}
+        </div>
+      ))}
+
+      <button type="button" onClick={addRow}>
+        Add row
+      </button>
+
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+When a row is removed, the input for that index unmounts. Rapid Form detects the removal on the next render and removes the matching error and value. The error span for that row disappears along with the row itself.
+
+:::tip
+Using the array index as part of the field name (`email.0`, `email.1`, …) keeps names stable relative to their position. If you need stable names across reordering, use a unique ID instead: `email.${row.id}`.
+:::
+
+---
+
+## How it works
+
+Rapid Form relies on an **inline ref callback** pattern:
+
+```tsx
+<form ref={(ref) => refValidation(ref, options)}>
+```
+
+Because the callback is an arrow function defined inline, React creates a new function reference on every render. React calls the old callback with `null` (unmount) and the new callback with the DOM node (mount) on each render cycle. Rapid Form uses these calls to synchronously scan which named fields are present and remove any that have disappeared.
+
+A **MutationObserver** is also attached to the form element as a safety net — it picks up fields added or removed by non-React code (e.g. direct DOM manipulation or third-party libraries) outside of the React render cycle.
+
+---
+
+## Limitations
+
+Field names that clash with JavaScript built-in object properties are silently ignored for security reasons. Avoid using the following names:
+
+- `__proto__`
+- `constructor`
+- `prototype`
+
+All other field names work as expected.

--- a/packages/docs/src/content/docs/guides/dynamic-fields.mdx
+++ b/packages/docs/src/content/docs/guides/dynamic-fields.mdx
@@ -13,7 +13,7 @@ The standard `useRapidForm` hook and an inline `ref` callback on `<form>` are al
 
 ## Conditional fields
 
-Use a boolean state value to mount or unmount a field. When the field disappears from the DOM, Rapid Form removes its entry from both `errors` and `values` automatically.
+Use a boolean state value to mount or unmount a field. When the field disappears from the DOM, Rapid Form removes its entry from `errors` state automatically.
 
 ```tsx
 import { useState } from 'react';
@@ -65,7 +65,7 @@ Validation rules listed under `validations` for a field that is not currently mo
 
 ## Field arrays
 
-A field array is a dynamic list of rows where each row contains one or more inputs. Use an array in state to drive the list, and give each input a unique name (e.g. `email.0`, `email.1`). When a row is removed, Rapid Form cleans up the corresponding errors and values.
+A field array is a dynamic list of rows where each row contains one or more inputs. Use an array in state to drive the list, and give each input a unique name (e.g. `email.0`, `email.1`). When a row is removed, Rapid Form clears the corresponding error from state.
 
 ```tsx
 import { useState } from 'react';
@@ -132,7 +132,7 @@ Rapid Form relies on an **inline ref callback** pattern:
 <form ref={(ref) => refValidation(ref, options)}>
 ```
 
-When a field is removed from the DOM, the next render's ref callback fires and rapid-form synchronously compares the current field list against its registry, dispatching a cleanup action for any missing fields.
+When a field is removed from the DOM, rapid-form's ref callback synchronously compares the current field list against its registry and dispatches a cleanup action for any missing fields.
 
 A **MutationObserver** is also attached to the form element as a safety net — it picks up fields added or removed by non-React code (e.g. direct DOM manipulation or third-party libraries) outside of the React render cycle.
 

--- a/packages/docs/src/content/docs/guides/dynamic-fields.mdx
+++ b/packages/docs/src/content/docs/guides/dynamic-fields.mdx
@@ -55,7 +55,7 @@ export function ConditionalFieldForm() {
 }
 ```
 
-When the checkbox is unchecked, the `phone` field unmounts. Rapid Form detects the removal and clears `errors['phone']` and `values['phone']` — the error span disappears along with the field.
+When the checkbox is unchecked, the `phone` field unmounts. Rapid Form detects the removal and clears the `phone` error from state — the error span disappears along with the field.
 
 :::note
 Validation rules listed under `validations` for a field that is not currently mounted are never triggered. You can safely keep the full validation config in one place.
@@ -84,13 +84,10 @@ export function EmailListForm() {
   const removeRow = (id: number) =>
     setRows((prev) => prev.filter((r) => r.id !== id));
 
-  // Build validations dynamically for however many rows exist
-  const validations = Object.fromEntries(
-    rows.map((_, i) => [`email.${i}`, { required: true, type: 'email' as const }])
-  );
-
   return (
-    <form ref={(ref) => refValidation(ref, { validations })}>
+    <form ref={(ref) => refValidation(ref, { validations: Object.fromEntries(
+      rows.map((_, i) => [`email.${i}`, { required: true, type: 'email' as const }])
+    )})}>
       {rows.map((row, i) => (
         <div key={row.id}>
           <input
@@ -119,7 +116,7 @@ export function EmailListForm() {
 }
 ```
 
-When a row is removed, the input for that index unmounts. Rapid Form detects the removal on the next render and removes the matching error and value. The error span for that row disappears along with the row itself.
+When a row is removed, the input for that index unmounts. Rapid Form detects the removal and removes the matching error from state. The error span for that row disappears along with the row itself.
 
 :::tip
 Using the array index as part of the field name (`email.0`, `email.1`, …) keeps names stable relative to their position. If you need stable names across reordering, use a unique ID instead: `email.${row.id}`.
@@ -135,7 +132,7 @@ Rapid Form relies on an **inline ref callback** pattern:
 <form ref={(ref) => refValidation(ref, options)}>
 ```
 
-Because the callback is an arrow function defined inline, React creates a new function reference on every render. React calls the old callback with `null` (unmount) and the new callback with the DOM node (mount) on each render cycle. Rapid Form uses these calls to synchronously scan which named fields are present and remove any that have disappeared.
+When a field is removed from the DOM, the next render's ref callback fires and rapid-form synchronously compares the current field list against its registry, dispatching a cleanup action for any missing fields.
 
 A **MutationObserver** is also attached to the form element as a safety net — it picks up fields added or removed by non-React code (e.g. direct DOM manipulation or third-party libraries) outside of the React render cycle.
 

--- a/packages/docs/src/content/docs/reference/api-reference.mdx
+++ b/packages/docs/src/content/docs/reference/api-reference.mdx
@@ -47,6 +47,10 @@ Attaches Rapid Form's validation listeners to a form element. Typically called i
 | `ref` | `HTMLFormElement \| null` | Yes | The native form element. React passes `null` when the component unmounts — the function handles this safely. |
 | `config` | `Config` | No | Optional configuration object. See [Config](#config) below. |
 
+:::caution[Reserved field names]
+Fields named `__proto__`, `constructor`, or `prototype` are silently ignored by rapid-form for security reasons. Validation listeners are never attached to these fields and their values will not appear in `errors` or `values`.
+:::
+
 ---
 
 ## `Config`
@@ -153,7 +157,7 @@ type FieldError = {
 | `name` | `string` | The `name` attribute of the form field. |
 | `value` | `string` | The current value of the field at the time the error was recorded. |
 | `isInvalid` | `boolean` | `true` when the field fails validation, `false` when it passes. Use this as the primary flag for disabling submit buttons or showing error UI. |
-| `errorType` | `'invalidFormat' \| undefined` | Set to `'invalidFormat'` for built-in format checks (e.g. email regex, password length). `undefined` for custom validation errors. |
+| `errorType` | `'invalidFormat' \| undefined` | Set to `'invalidFormat'` for built-in format checks (e.g. email format, password length). `undefined` for custom validation errors. |
 | `message` | `string \| undefined` | Human-readable error message. Populated from the `message` property of a `ValidationEntry`, or a built-in default message for format errors. |
 
 **Typical usage:**

--- a/packages/docs/src/content/docs/why-rapid-form.mdx
+++ b/packages/docs/src/content/docs/why-rapid-form.mdx
@@ -17,20 +17,19 @@ Most applications ship the same handful of forms: login, signup, contact, settin
 | Schema validation | ✅ Zod / Yup / etc | ✅ Zod / Yup / etc | ✅ Yup |
 | DevTools | ❌ | ✅ | ❌ |
 | Cross-field validation | ✅ via resolver or `formElements` | ✅ | ✅ |
-| Form arrays / dynamic fields | ❌ | ✅ | ✅ |
+| Form arrays / dynamic fields | ✅ | ✅ | ✅ |
 
 ## When to use rapid-form
 
 - **Login and signup forms** — email, password, maybe a confirm-password check.
 - **Contact forms** — name, email, message, submit. Done.
 - **Settings and profile forms** — a fixed set of fields the user fills in and saves.
-- **Any form where fields are known at build time** — if you're not generating fields dynamically at runtime, rapid-form handles it.
+- **Forms with dynamic fields** — conditional fields and field arrays work out of the box; rapid-form tracks additions and removals automatically.
 - **When bundle size matters** — shipping to mobile users, low-bandwidth markets, or any product where every kilobyte counts.
 - **When you want schema validation without the overhead** — plug in Zod or Yup via the built-in resolver adapters; only the adapter you import is added to your bundle.
 
 ## When NOT to use rapid-form
 
-- **Highly dynamic forms** — field arrays, nested object structures, or fields that are added and removed at runtime are not supported.
 - **DevTools and form state inspection** — rapid-form has no browser extension or debug panel. react-hook-form's DevTools are excellent for complex forms.
 - **Multi-step wizard forms with shared state** — managing cross-step validation and accumulated form data is outside rapid-form's scope.
 


### PR DESCRIPTION
Closes #67

## Changes

### New guide: Dynamic Fields
- `guides/dynamic-fields.mdx` — covers conditional fields, field arrays, how-it-works, and reserved name limitations
- `astro.config.mjs` — Dynamic Fields added to sidebar (after Schema Validation)

### Updated: Why Rapid Form? + README
- Comparison table: `Form arrays / dynamic fields` flipped ❌ → ✅
- "When to use": replaced "fields known at build time" with dynamic fields bullet
- "When NOT to use": removed "Highly dynamic forms" bullet
- `README.md`: added Dynamic fields row to comparison table + new section with code example

### Updated: API Reference
- Added `:::caution[Reserved field names]` after `refValidation` parameters — documents that `__proto__`, `constructor`, `prototype` are silently ignored
- `errorType` description: "email regex" → "email format" (reflects native `validity.valid` validation)

## Test plan
- [ ] Docs build passes (`pnpm --filter docs build`) — verified clean, 0 errors, 17 pages