### PR TITLE
v4.0.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "npmClient": "pnpm",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "command": {
     "version": {
       "preid": "beta"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "docs",
   "type": "module",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/packages/rapid-form/package.json
+++ b/packages/rapid-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rapid-form",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": false,
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Bump version to 4.0.1. Adds `"sideEffects": false` to enable full tree-shaking and fix bundlephobia exports analysis (closes #70).