### PR TITLE
🐛 fix: wire listeners onto fields mounted after initial render

### DIFF
--- a/packages/rapid-form/specs/dynamic-fields.spec.tsx
+++ b/packages/rapid-form/specs/dynamic-fields.spec.tsx
@@ -97,6 +97,41 @@ function SimpleForm() {
   );
 }
 
+// Mimics a child that mounts its fields only after an async operation settles
+// (e.g. a settings fetch). Its state change re-renders ONLY this child — the
+// parent form component does not re-render, so the ref callback never re-runs.
+function AsyncChildFields() {
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setSettled(true), 10);
+    return () => clearTimeout(t);
+  }, []);
+  if (!settled) return null;
+  return (
+    <select name="country" data-testid="country" required defaultValue="">
+      <option value="" disabled>
+        Select a country
+      </option>
+      <option value="IT">Italy</option>
+      <option value="FR">France</option>
+    </select>
+  );
+}
+
+function DescendantOnlyRenderForm() {
+  const { refValidation, values, errors, numberOfRequiredFields } =
+    useRapidForm();
+  return (
+    <form ref={(ref) => refValidation(ref)}>
+      <AsyncChildFields />
+      <span data-testid="country-value">{values.country?.value ?? ''}</span>
+      <span data-testid="country-error">{errors.country?.message ?? ''}</span>
+      <span data-testid="required-count">{numberOfRequiredFields}</span>
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+
 function NullBeforeMountForm() {
   const { refValidation } = useRapidForm();
   useEffect(() => {
@@ -202,6 +237,38 @@ describe('Dynamic fields', () => {
 
   test('refValidation(null) is safe when no form was ever mounted', () => {
     expect(() => render(<NullBeforeMountForm />)).not.toThrow();
+  });
+
+  test('field mounted by a descendant-only render gets a listener', async () => {
+    const user = userEvent.setup();
+    render(<DescendantOnlyRenderForm />);
+
+    // the select mounts after the child's async state settles — the form
+    // component itself never re-renders, so only the MutationObserver can
+    // wire it
+    const country = await screen.findByTestId('country');
+
+    await user.selectOptions(country, 'IT');
+
+    // without the observer wiring the late field, this value never reaches
+    // form state
+    await waitFor(() =>
+      expect(screen.getByTestId('country-value').textContent).toBe('IT')
+    );
+  });
+
+  test('required count is synced when fields mount without a form re-render', async () => {
+    render(<DescendantOnlyRenderForm />);
+
+    // before the async child settles, no required fields are known
+    expect(screen.getByTestId('required-count').textContent).toBe('0');
+
+    await screen.findByTestId('country');
+
+    // observer wires the late field and syncs the required-field count
+    await waitFor(() =>
+      expect(screen.getByTestId('required-count').textContent).toBe('1')
+    );
   });
 
   test('MutationObserver cleans up field removed via direct DOM manipulation', async () => {

--- a/packages/rapid-form/src/validation.ts
+++ b/packages/rapid-form/src/validation.ts
@@ -171,7 +171,6 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
 
   const countRequired = (): number =>
     Array.from(elements).filter((e) => e?.hasAttribute('required')).length;
-  const numberOfRequiredFields = countRequired();
 
   // Sync cleanup: dispatch removeField for names that were registered but are no longer in the DOM.
   // This runs on every re-render (React calls the ref callback each render), so it reliably
@@ -183,7 +182,11 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
   }
   for (const name of getRegisteredNames(ref)) {
     if (!currentNames.has(name)) {
-      dispatch?.({ type: 'removeField', name, numberOfRequiredFields });
+      dispatch?.({
+        type: 'removeField',
+        name,
+        numberOfRequiredFields: countRequired()
+      });
       getRegisteredNames(ref).delete(name);
     }
   }
@@ -192,6 +195,7 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
   const needsSubmitListener = resolver != null || resetOnSubmit;
   if (needsSubmitListener && !hasEventListener(ref, 'submit')) {
     addTrackedEventListener(ref, 'submit', (e) => {
+      const numberOfRequiredFields = countRequired();
       if (resolver) {
         e.preventDefault();
         void dispatchResolverResults(
@@ -210,91 +214,106 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
     });
   }
 
-  // Field event listeners
-  for (const element of Array.from(elements)) {
-    const name = element.getAttribute('name');
-    if (!name) continue;
+  // Field event listeners. Idempotent (guarded by hasEventListener), so it can
+  // run both on every validation() call and from the MutationObserver when
+  // fields mount after the initial render. Returns how many fields got wired.
+  const attachFieldListeners = (): number => {
+    let wired = 0;
+    for (const element of Array.from(elements)) {
+      const name = element.getAttribute('name');
+      if (!name) continue;
 
-    if (resolver) {
-      // Resolver mode: attach to every named field; run the full resolver.
-      const elementEventType =
-        config?.validations?.[name]?.eventType ?? eventType;
-      if (hasEventListener(element, elementEventType)) continue;
-      registerFieldName(ref, name);
-      addTrackedEventListener(element, elementEventType, () => {
-        void dispatchResolverResults(
-          resolver,
-          elements,
-          dispatch,
-          numberOfRequiredFields
-        );
-      });
-    } else {
-      // Per-field mode: only attach to required / custom-validated fields.
-      const isRequired = element.hasAttribute('required');
-      const hasCustomValidation = config?.validations?.[name] != null;
-      if (!isRequired && !hasCustomValidation) continue;
-      const elementEventType =
-        config?.validations?.[name]?.eventType ?? eventType;
-      if (hasEventListener(element, elementEventType)) continue;
-      registerFieldName(ref, name);
-      addTrackedEventListener(element, elementEventType, (e) => {
-        const target = e.target as HTMLInputElement;
-        const val = target.value.trim();
-        const isValid =
-          config?.validations?.[target.name]?.validation != null
-            ? config.validations[target.name]?.validation({
-                value: val,
-                formElements: elements
-              })
-            : inputValidation({
-                type: target.type,
-                value: val,
-                element: target
-              });
-        if (isValid === false) {
-          dispatch?.({
-            type: 'setError',
-            values: { [target.name]: { name: target.name, value: val } },
-            errors: {
-              [target.name]: {
-                name: target.name,
-                value: val,
-                isInvalid: true,
-                errorType: 'invalidFormat',
-                message:
-                  config?.validations?.[target.name]?.message ??
-                  'Invalid format or required field'
-              }
-            },
-            numberOfRequiredFields
-          });
-        } else {
-          dispatch?.({
-            type: 'setValue',
-            values: { [target.name]: { name: target.name, value: val } },
-            errors: {
-              [target.name]: {
-                name: target.name,
-                value: val,
-                isInvalid: false,
-                message: ''
-              }
-            },
-            numberOfRequiredFields
-          });
-        }
-      });
+      if (resolver) {
+        // Resolver mode: attach to every named field; run the full resolver.
+        const elementEventType =
+          config?.validations?.[name]?.eventType ?? eventType;
+        if (hasEventListener(element, elementEventType)) continue;
+        registerFieldName(ref, name);
+        wired++;
+        addTrackedEventListener(element, elementEventType, () => {
+          void dispatchResolverResults(
+            resolver,
+            elements,
+            dispatch,
+            countRequired()
+          );
+        });
+      } else {
+        // Per-field mode: only attach to required / custom-validated fields.
+        const isRequired = element.hasAttribute('required');
+        const hasCustomValidation = config?.validations?.[name] != null;
+        if (!isRequired && !hasCustomValidation) continue;
+        const elementEventType =
+          config?.validations?.[name]?.eventType ?? eventType;
+        if (hasEventListener(element, elementEventType)) continue;
+        registerFieldName(ref, name);
+        wired++;
+        addTrackedEventListener(element, elementEventType, (e) => {
+          const target = e.target as HTMLInputElement;
+          const val = target.value.trim();
+          const numberOfRequiredFields = countRequired();
+          const isValid =
+            config?.validations?.[target.name]?.validation != null
+              ? config.validations[target.name]?.validation({
+                  value: val,
+                  formElements: elements
+                })
+              : inputValidation({
+                  type: target.type,
+                  value: val,
+                  element: target
+                });
+          if (isValid === false) {
+            dispatch?.({
+              type: 'setError',
+              values: { [target.name]: { name: target.name, value: val } },
+              errors: {
+                [target.name]: {
+                  name: target.name,
+                  value: val,
+                  isInvalid: true,
+                  errorType: 'invalidFormat',
+                  message:
+                    config?.validations?.[target.name]?.message ??
+                    'Invalid format or required field'
+                }
+              },
+              numberOfRequiredFields
+            });
+          } else {
+            dispatch?.({
+              type: 'setValue',
+              values: { [target.name]: { name: target.name, value: val } },
+              errors: {
+                [target.name]: {
+                  name: target.name,
+                  value: val,
+                  isInvalid: false,
+                  message: ''
+                }
+              },
+              numberOfRequiredFields
+            });
+          }
+        });
+      }
     }
-  }
+    return wired;
+  };
+  attachFieldListeners();
 
-  // MutationObserver — safety net for field removals that happen outside React
-  // (e.g. vanilla JS DOM manipulation). React-driven removals are already handled
-  // synchronously above via the registered-names check on each re-render.
+  // MutationObserver — safety net for DOM changes that happen without the form
+  // component re-rendering: fields removed outside React (vanilla JS DOM
+  // manipulation) AND fields mounted by descendant-only renders (e.g. a child
+  // component that returns null until an async fetch settles). React-driven
+  // changes that re-render the form are already handled synchronously above,
+  // since React re-invokes the ref callback on each render.
   // Disconnect any previous observer before creating a new one so observers
   // don't accumulate across re-renders.
   disconnectObserver(ref);
   const observer = new MutationObserver(() => {
+    // Wire any fields that mounted since the last validation() run.
+    const wired = attachFieldListeners();
     const names = new Set<string>();
     for (const el of Array.from(elements)) {
       const n = el.getAttribute('name');
@@ -309,6 +328,16 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
         });
         getRegisteredNames(ref).delete(name);
       }
+    }
+    if (wired > 0) {
+      // Fields appeared without a form re-render: sync numberOfRequiredFields
+      // so consumers relying on it see the late-mounted fields.
+      dispatch?.({
+        type: 'setValue',
+        values: {},
+        errors: {},
+        numberOfRequiredFields: countRequired()
+      });
     }
   });
   observer.observe(ref, { childList: true, subtree: true });


### PR DESCRIPTION
Closes #74

## Problem

`validation()` attached input listeners only to the elements present in `form.elements` at the moment `refValidation` ran, and the internal `MutationObserver` only handled **removals** — it never wired newly added fields.

When a field mounts via a **descendant-only render** (the form component itself doesn't re-render — e.g. a child component that returns `null` until an async fetch settles, as in `mfe-checkout`'s address form), the ref callback never re-runs, so the field gets no listener. User input updates the DOM but never reaches form `values`, and since state never changes, nothing ever re-renders the form to repair the subscription. In `mfe-checkout` this made country selection silently ignored ~20–30% of the time, depending on whether unrelated context updates happened to re-render the form after the fields mounted.

## Fix

- Extract the field-wiring loop into an idempotent `attachFieldListeners()` (guarded by the existing `hasEventListener` checks) and call it from the `MutationObserver` callback, so fields mounted after the initial render get wired.
- When the observer wires new fields, dispatch a state sync so `numberOfRequiredFields` reflects the new DOM without waiting for the first user input.
- Compute the required-field count at dispatch time (`countRequired()`) instead of capturing a stale value at wiring time — late-mounted required fields previously left the count stale in every subsequent dispatch.

## Tests

Two new regression tests in `dynamic-fields.spec.tsx` model the real scenario: a child component that mounts a required `<select name="country">` after an async delay, without the form component ever re-rendering. Both fail on `main` and pass with this fix. Full suite: 49/49 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)