### PR TITLE
🐛 fix: report checkbox checked state in per-field mode values

### DIFF
--- a/packages/docs/src/content/docs/reference/api-reference.mdx
+++ b/packages/docs/src/content/docs/reference/api-reference.mdx
@@ -210,7 +210,7 @@ import type { Config, Value, FieldError, NumberOfRequiredFields, SchemaResolver 
 | Type | Definition | Description |
 |------|------------|-------------|
 | `Config` | `{ eventType?: EventType; resetOnSubmit?: boolean; validations?: Record<string, ValidationEntry>; resolver?: SchemaResolver }` | The optional config parameter accepted by `refValidation`. |
-| `Value` | `{ name: string; value: string }` | Shape of each entry in the `values` map returned by `useRapidForm`. |
+| `Value` | `{ name: string; value: string }` | Shape of each entry in the `values` map returned by `useRapidForm`. Checkbox fields report their checked state as `'true'` / `'false'`, ignoring any `value` attribute. |
 | `FieldError` | `{ name: string; value: string; isInvalid: boolean; errorType?: 'invalidFormat'; message?: string }` | Shape of each entry in the `errors` map returned by `useRapidForm`. |
 | `NumberOfRequiredFields` | `number` | Alias for the `numberOfRequiredFields` return value. |
 | `SchemaResolver` | `(values: Record<string, string>) => Record<string, string \| undefined> \| Promise<...>` | Schema resolver function type. Use with the built-in adapters or write your own. |

--- a/packages/rapid-form/specs/checkbox-values.spec.tsx
+++ b/packages/rapid-form/specs/checkbox-values.spec.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import { useRapidForm } from '../src/index.js';
+import type { ValidationProps } from '../src/validation.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function CheckboxForm({ config }: { config?: ValidationProps['config'] }) {
+  const { refValidation, values, errors } = useRapidForm();
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref, config);
+      }}
+    >
+      <input type="checkbox" name="terms" data-testid="terms" required />
+      <span data-testid="terms-value">{values.terms?.value}</span>
+      <span data-testid="terms-invalid">{String(errors.terms?.isInvalid)}</span>
+      <button data-testid="submit-button" type="submit">
+        Submit
+      </button>
+    </form>
+  );
+}
+
+/** A checkbox carrying an explicit `value` attribute, the other `'on'` source. */
+function ValuedCheckboxForm() {
+  const { refValidation, values } = useRapidForm();
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref);
+      }}
+    >
+      <input
+        type="checkbox"
+        name="plan"
+        value="premium"
+        data-testid="plan"
+        required
+      />
+      <span data-testid="plan-value">{values.plan?.value}</span>
+    </form>
+  );
+}
+
+// ── specs ────────────────────────────────────────────────────────────────────
+
+describe('checkbox values in per-field mode', () => {
+  test('reports checked state rather than the value attribute', async () => {
+    const user = userEvent.setup();
+    render(<CheckboxForm config={{ resetOnSubmit: false }} />);
+    const terms = screen.getByTestId('terms');
+    await user.click(terms);
+    expect(screen.getByTestId('terms-value').textContent).toBe('true');
+    await user.click(terms);
+    expect(screen.getByTestId('terms-value').textContent).toBe('false');
+  });
+
+  test('ignores an explicit value attribute', async () => {
+    const user = userEvent.setup();
+    render(<ValuedCheckboxForm />);
+    await user.click(screen.getByTestId('plan'));
+    expect(screen.getByTestId('plan-value').textContent).toBe('true');
+  });
+
+  test('still validates a required checkbox by its checked state', async () => {
+    const user = userEvent.setup();
+    render(<CheckboxForm config={{ resetOnSubmit: false }} />);
+    const terms = screen.getByTestId('terms');
+    await user.click(terms);
+    expect(screen.getByTestId('terms-invalid').textContent).toBe('false');
+    await user.click(terms);
+    expect(screen.getByTestId('terms-invalid').textContent).toBe('true');
+  });
+
+  test('passes the checked state to a custom validation function', async () => {
+    const user = userEvent.setup();
+    const seen: string[] = [];
+    render(
+      <CheckboxForm
+        config={{
+          resetOnSubmit: false,
+          validations: {
+            terms: {
+              validation: ({ value }) => {
+                seen.push(value);
+                return value === 'true';
+              },
+              message: 'You must accept the terms'
+            }
+          }
+        }}
+      />
+    );
+    const terms = screen.getByTestId('terms');
+    await user.click(terms);
+    await user.click(terms);
+    expect(seen).toEqual(['true', 'false']);
+  });
+});

--- a/packages/rapid-form/src/validation.ts
+++ b/packages/rapid-form/src/validation.ts
@@ -91,6 +91,16 @@ function inputValidation({
   }
 }
 
+/**
+ * The state value for a field. Checkboxes report their checked state rather
+ * than their `value` attribute, which is `'on'` whether checked or not.
+ */
+function fieldValue(element: HTMLInputElement): string {
+  return element.type === 'checkbox'
+    ? String(element.checked)
+    : element.value.trim();
+}
+
 const UNSAFE_FIELD_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
 
 /** Collect all named field values from a form's element collection. */
@@ -101,9 +111,7 @@ function collectFormValues(
   for (const el of Array.from(elements)) {
     const name = el.getAttribute('name');
     if (!name || UNSAFE_FIELD_NAMES.has(name)) continue;
-    const input = el as HTMLInputElement;
-    values[name] =
-      input.type === 'checkbox' ? String(input.checked) : input.value.trim();
+    values[name] = fieldValue(el as HTMLInputElement);
   }
   return values;
 }
@@ -250,7 +258,7 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
         wired++;
         addTrackedEventListener(element, elementEventType, (e) => {
           const target = e.target as HTMLInputElement;
-          const val = target.value.trim();
+          const val = fieldValue(target);
           const numberOfRequiredFields = countRequired();
           const isValid =
             config?.validations?.[target.name]?.validation != null


### PR DESCRIPTION
Closes #80

Split out of #79, where this was found. It stands alone as a fix and carries an observable behavior change, so it deserves its own review and release note.

## Problem

Per-field mode stored `target.value.trim()` for every field type. A checkbox's `.value` is `'on'` whether checked or not, so `values[name].value` told you nothing about its state — and the same `'on'` reached custom validation functions.

| mode | `values.terms.value` checked | unchecked |
| --- | --- | --- |
| per-field (before) | `'on'` | `'on'` |
| resolver | `'true'` | `'false'` |

## Fix

One `fieldValue()` helper, shared by both modes. On `main` the per-field listener's `val` feeds both the dispatch and the validation call, so this is a two-line change plus the helper.

The duplication is *why* the modes drifted — `collectFormValues` had already solved this and the per-field path never learned about it.

## Why no existing test caught it

`inputValidation` reads `element.checked` directly for the `checkbox` case, so **validation was always correct**. Only the stored value was wrong, and since it was a constant, nothing asserted on it. All 49 existing tests pass unchanged.

## ⚠️ Behavior change

`values[name].value` for checkboxes: `'on'` → `'true'`/`'false'`. Same for the `value` passed to custom checkbox validations. Real-world risk is low — the old value was uninformative — but anything comparing `=== 'on'` breaks. **Suggest a minor release with this listed explicitly.**

An explicit `value` attribute (`<input type="checkbox" value="premium">`) is now also ignored in favor of the checked state, matching resolver mode. Covered by a test.

## Tests

4 new tests in `specs/checkbox-values.spec.tsx`; 53/53 pass.

Covers: checked state reported, explicit `value` attribute ignored, required-checkbox validation still driven by checked state (regression guard), and custom validation receiving `'true'`/`'false'`.

Mutation-checked: reverting `fieldValue(target)` to `target.value.trim()` fails 3 of the 4. The fourth is the validation regression guard — it passes either way by design, since validation reads `element.checked` directly.

## Merge order with #79

**Whichever merges second hits a small conflict.** I trial-merged both to confirm, rather than assume:

1. `validation.ts` — both PRs add a new top-level function at the same anchor (immediately before `UNSAFE_FIELD_NAMES`). Resolution: keep both `fieldValue()` and `resolveValidity()`.
2. `api-reference.mdx` — both edit adjacent rows of the exported-types table (`Value` here, `Config` in #79). Resolution: keep both edited rows.

Then one follow-up edit: point #79's `resolveValidity` at this PR's `fieldValue()` so custom validations on checkboxes also receive the checked state.

I verified the resolved end state locally — typecheck clean, **59/59 tests pass**. Order doesn't matter; I'll handle the resolution on whichever lands second.

## Not addressed

Radio groups and `<select multiple>` are still wrong in both modes — radios report the last-touched value, multi-selects only the first. Deliberately out of scope; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)