### PR TITLE
fix: collect radio group values correctly

### DIFF
--- a/packages/rapid-form/package.json
+++ b/packages/rapid-form/package.json
@@ -76,6 +76,7 @@
     "react-dom": "^19.2.7",
     "tsdown": "^0.22.8",
     "typescript": "^7.0.2",
+    "unrun": "^0.3.1",
     "vitest": "^4.1.10"
   },
   "peerDependencies": {

--- a/packages/rapid-form/specs/radio-groups.spec.tsx
+++ b/packages/rapid-form/specs/radio-groups.spec.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import { type SchemaResolver, useRapidForm } from '../src/index.js';
+
+function RadioResolverForm({ resolver }: { resolver: SchemaResolver }) {
+  const { refValidation, values, numberOfRequiredFields } = useRapidForm();
+
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref, { resolver });
+      }}
+    >
+      <label>
+        <input
+          type="radio"
+          name="plan"
+          value="free"
+          data-testid="plan-free"
+          required
+        />
+        Free
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="plan"
+          value="pro"
+          data-testid="plan-pro"
+          required
+        />
+        Pro
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="plan"
+          value="max"
+          data-testid="plan-max"
+          required
+        />
+        Max
+      </label>
+      <span data-testid="plan-value">{values.plan?.value ?? ''}</span>
+      <span data-testid="required-count">{numberOfRequiredFields}</span>
+    </form>
+  );
+}
+
+describe('radio groups', () => {
+  test('resolver mode collects the checked radio value', async () => {
+    const seenValues: Record<string, string>[] = [];
+    const resolver: SchemaResolver = (values) => {
+      seenValues.push(values);
+      return {};
+    };
+    const user = userEvent.setup();
+
+    render(<RadioResolverForm resolver={resolver} />);
+
+    await user.click(screen.getByTestId('plan-pro'));
+
+    await waitFor(() =>
+      expect(seenValues.at(-1)).toEqual(
+        expect.objectContaining({ plan: 'pro' })
+      )
+    );
+    expect(screen.getByTestId('plan-value').textContent).toBe('pro');
+  });
+
+  test('required radio groups count as one required field', async () => {
+    const resolver: SchemaResolver = () => ({});
+    const user = userEvent.setup();
+
+    render(<RadioResolverForm resolver={resolver} />);
+
+    await user.click(screen.getByTestId('plan-pro'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('required-count').textContent).toBe('1')
+    );
+  });
+});

--- a/packages/rapid-form/src/validation.ts
+++ b/packages/rapid-form/src/validation.ts
@@ -104,10 +104,25 @@ function inputValidation({
  * The state value for a field. Checkboxes report their checked state rather
  * than their `value` attribute, which is `'on'` whether checked or not.
  */
-function fieldValue(element: HTMLInputElement): string {
-  return element.type === 'checkbox'
-    ? String(element.checked)
-    : element.value.trim();
+function fieldValue(
+  element: HTMLInputElement,
+  elements?: HTMLFormControlsCollection
+): string {
+  if (element.type === 'checkbox') return String(element.checked);
+  if (element.type === 'radio') {
+    if (elements == null) {
+      return element.checked ? element.value.trim() : '';
+    }
+    const checked = Array.from(elements).find(
+      (candidate): candidate is HTMLInputElement =>
+        candidate instanceof HTMLInputElement &&
+        candidate.type === 'radio' &&
+        candidate.name === element.name &&
+        candidate.checked
+    );
+    return checked?.value.trim() ?? '';
+  }
+  return element.value.trim();
 }
 
 /**
@@ -152,7 +167,7 @@ function collectFormValues(
   for (const el of Array.from(elements)) {
     const name = el.getAttribute('name');
     if (!name || UNSAFE_FIELD_NAMES.has(name)) continue;
-    values[name] = fieldValue(el as HTMLInputElement);
+    values[name] = fieldValue(el as HTMLInputElement, elements);
   }
   return values;
 }
@@ -220,7 +235,12 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
   const trackUnvalidatedFields = config?.trackUnvalidatedFields ?? false;
 
   const countRequired = (): number =>
-    Array.from(elements).filter((e) => e?.hasAttribute('required')).length;
+    new Set(
+      Array.from(elements)
+        .filter((e) => e?.hasAttribute('required'))
+        .map((e) => e.getAttribute('name'))
+        .filter((name): name is string => name != null && name.length > 0)
+    ).size;
 
   // Sync cleanup: dispatch removeField for names that were registered but are no longer in the DOM.
   // This runs on every re-render (React calls the ref callback each render), so it reliably

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,10 +70,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       tsdown:
         specifier: ^0.22.8
-        version: 0.22.8(typescript@7.0.2)
+        version: 0.22.8(typescript@7.0.2)(unrun@0.3.1)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      unrun:
+        specifier: ^0.3.1
+        version: 0.3.1
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
@@ -4827,6 +4830,16 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   unstorage@1.17.5:
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
@@ -10468,7 +10481,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.8(typescript@7.0.2):
+  tsdown@0.22.8(typescript@7.0.2)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -10487,6 +10500,7 @@ snapshots:
       unconfig-core: 7.5.0
     optionalDependencies:
       typescript: 7.0.2
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -10629,6 +10643,10 @@ snapshots:
   universal-user-agent@6.0.1: {}
 
   universalify@2.0.1: {}
+
+  unrun@0.3.1:
+    dependencies:
+      rolldown: 1.1.5
 
   unstorage@1.17.5:
     dependencies:


### PR DESCRIPTION
## What changed
Radio groups now resolve their form state from the checked input instead of whichever same-name radio appears last in DOM order. Required field counting now treats a required radio group as one named field, and the new radio-group regression spec covers both resolver-mode value collection and required-count behavior.

## Why
Fixes #83. Resolver mode collects values from the whole form, so iterating each radio independently overwrote `plan` with the last radio value even when a different option was checked. Counting required elements also inflated normal required radio groups because each member carries the `required` attribute. I also declared `unrun`, which `tsdown` needs while loading `tsdown.config.ts`, so the existing package build can run from a fresh install.

## How to test
1. `npm exec --yes pnpm@11.17.0 -- install --frozen-lockfile`
2. `npm exec --yes pnpm@11.17.0 -- --filter rapid-form test -- specs/radio-groups.spec.tsx`
3. `npm exec --yes pnpm@11.17.0 -- --filter rapid-form test`
4. `npm exec --yes pnpm@11.17.0 -- rapid-form:test:coverage`
5. `npm exec --yes pnpm@11.17.0 -- build`
6. `npm exec --yes pnpm@11.17.0 -- exec biome check packages/rapid-form/package.json packages/rapid-form/src/validation.ts packages/rapid-form/specs/radio-groups.spec.tsx pnpm-lock.yaml`
7. `git diff --check`

I also confirmed the new radio spec fails on the previous implementation: resolver mode reported `plan: "max"` after clicking `pro`, and required count reported `3` instead of `1`.