### PR TITLE
🐛 fix: resolve radio groups as one field for value and required-count

### DIFF
--- a/packages/docs/src/content/docs/reference/api-reference.mdx
+++ b/packages/docs/src/content/docs/reference/api-reference.mdx
@@ -22,7 +22,7 @@ const { refValidation, values, errors, numberOfRequiredFields } = useRapidForm()
 | `refValidation` | `(ref: HTMLFormElement \| null, config?: Config) => void` | Attaches validation logic to a form element. Pass it as the form's `ref` callback. |
 | `values` | `Record<string, Value>` | Live map of every tracked field, keyed by the field's `name` attribute. |
 | `errors` | `Record<string, FieldError>` | Map of validation errors for each field, keyed by the field's `name` attribute. Only fields that have been interacted with appear here. |
-| `numberOfRequiredFields` | `number` | Count of fields that carry the `required` attribute in the attached form. |
+| `numberOfRequiredFields` | `number` | Count of distinct **field names** that carry the `required` attribute in the attached form. A radio group counts once, however many members it has. Required elements without a `name` are not counted, since rapid-form never tracks them. |
 
 ---
 
@@ -225,7 +225,7 @@ import type { Config, Value, FieldError, NumberOfRequiredFields, SchemaResolver 
 | Type | Definition | Description |
 |------|------------|-------------|
 | `Config` | `{ eventType?: EventType; resetOnSubmit?: boolean; validations?: Record<string, ValidationEntry>; resolver?: SchemaResolver; trackUnvalidatedFields?: boolean }` | The optional config parameter accepted by `refValidation`. |
-| `Value` | `{ name: string; value: string }` | Shape of each entry in the `values` map returned by `useRapidForm`. Checkbox fields report their checked state as `'true'` / `'false'`, ignoring any `value` attribute. |
+| `Value` | `{ name: string; value: string }` | Shape of each entry in the `values` map returned by `useRapidForm`. Checkbox fields report their checked state as `'true'` / `'false'`, ignoring any `value` attribute. A radio group is one entry keyed by its shared `name`, holding the selected member's value (`''` when nothing is selected). |
 | `FieldError` | `{ name: string; value: string; isInvalid: boolean; errorType?: 'invalidFormat'; message?: string }` | Shape of each entry in the `errors` map returned by `useRapidForm`. |
 | `NumberOfRequiredFields` | `number` | Alias for the `numberOfRequiredFields` return value. |
 | `SchemaResolver` | `(values: Record<string, string>) => Record<string, string \| undefined> \| Promise<...>` | Schema resolver function type. Use with the built-in adapters or write your own. |

--- a/packages/rapid-form/specs/radio-groups.spec.tsx
+++ b/packages/rapid-form/specs/radio-groups.spec.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import { useRapidForm } from '../src/index.js';
+import type { ValidationProps } from '../src/validation.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * A three-member radio group plus a text field. The text field gives resolver
+ * mode something to fire on without touching the radios, which is how the
+ * "nothing selected" case gets observed.
+ */
+function RadioForm({ config }: { config?: ValidationProps['config'] }) {
+  const { refValidation, values, numberOfRequiredFields } = useRapidForm();
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref, config);
+      }}
+    >
+      <input
+        type="radio"
+        name="plan"
+        value="free"
+        data-testid="free"
+        required
+      />
+      <input type="radio" name="plan" value="pro" data-testid="pro" required />
+      <input type="radio" name="plan" value="max" data-testid="max" required />
+      <input type="text" name="note" data-testid="note" required />
+      <span data-testid="plan-value">{values.plan?.value ?? 'UNSET'}</span>
+      <span data-testid="required-count">{numberOfRequiredFields}</span>
+    </form>
+  );
+}
+
+// ── specs ────────────────────────────────────────────────────────────────────
+
+describe('radio group values', () => {
+  test('per-field mode reports the selected member', async () => {
+    const user = userEvent.setup();
+    render(<RadioForm config={{ resetOnSubmit: false }} />);
+    await user.click(screen.getByTestId('pro'));
+    expect(screen.getByTestId('plan-value').textContent).toBe('pro');
+  });
+
+  test('per-field mode follows a changed selection', async () => {
+    const user = userEvent.setup();
+    render(<RadioForm config={{ resetOnSubmit: false }} />);
+    await user.click(screen.getByTestId('pro'));
+    await user.click(screen.getByTestId('free'));
+    expect(screen.getByTestId('plan-value').textContent).toBe('free');
+  });
+
+  test('resolver mode reports the selected member, not the last in DOM order', async () => {
+    const user = userEvent.setup();
+    const seen: Record<string, string>[] = [];
+    render(
+      <RadioForm
+        config={{
+          resetOnSubmit: false,
+          resolver: (values) => {
+            seen.push({ ...values });
+            return {};
+          }
+        }}
+      />
+    );
+    // `max` is last in DOM order and would previously have won regardless.
+    await user.click(screen.getByTestId('pro'));
+    expect(seen.at(-1)?.plan).toBe('pro');
+  });
+
+  test('an unselected group reports an empty string', async () => {
+    const user = userEvent.setup();
+    const seen: Record<string, string>[] = [];
+    render(
+      <RadioForm
+        config={{
+          resetOnSubmit: false,
+          resolver: (values) => {
+            seen.push({ ...values });
+            return {};
+          }
+        }}
+      />
+    );
+    // Type in the text field so the resolver runs without touching the radios.
+    await user.type(screen.getByTestId('note'), 'x');
+    expect(seen.at(-1)?.plan).toBe('');
+  });
+});
+
+describe('numberOfRequiredFields with radio groups', () => {
+  test('counts a radio group as one field', async () => {
+    const user = userEvent.setup();
+    render(<RadioForm config={{ resetOnSubmit: false }} />);
+    await user.click(screen.getByTestId('pro'));
+    // Three required radios + one required text input = 2 logical fields.
+    expect(screen.getByTestId('required-count').textContent).toBe('2');
+  });
+
+  test('ignores required elements that have no name', async () => {
+    const user = userEvent.setup();
+    function UnnamedForm() {
+      const { refValidation, numberOfRequiredFields } = useRapidForm();
+      return (
+        <form
+          ref={(ref) => {
+            refValidation(ref, { resetOnSubmit: false });
+          }}
+        >
+          <input type="text" name="named" data-testid="named" required />
+          {/* Untracked by rapid-form, so it must not inflate the count. */}
+          <input type="text" data-testid="unnamed" required />
+          <span data-testid="count">{numberOfRequiredFields}</span>
+        </form>
+      );
+    }
+    render(<UnnamedForm />);
+    await user.type(screen.getByTestId('named'), 'x');
+    expect(screen.getByTestId('count').textContent).toBe('1');
+  });
+});

--- a/packages/rapid-form/src/validation.ts
+++ b/packages/rapid-form/src/validation.ts
@@ -105,9 +105,35 @@ function inputValidation({
  * than their `value` attribute, which is `'on'` whether checked or not.
  */
 function fieldValue(element: HTMLInputElement): string {
-  return element.type === 'checkbox'
-    ? String(element.checked)
-    : element.value.trim();
+  if (element.type === 'checkbox') return String(element.checked);
+  if (element.type === 'radio') return radioGroupValue(element);
+  return element.value.trim();
+}
+
+/**
+ * The selected value of the radio group `element` belongs to, or `''` when
+ * nothing is selected.
+ *
+ * A radio group is one logical field spread across several elements, so the
+ * value can't be read off the visited element — every member shares the same
+ * `name` but only the checked one is meaningful. The group is walked via
+ * `element.form` rather than a `name`-derived selector, since names come from
+ * user markup.
+ */
+function radioGroupValue(element: HTMLInputElement): string {
+  const group = element.form?.elements;
+  if (group == null) return element.checked ? element.value.trim() : '';
+  for (const el of Array.from(group)) {
+    const radio = el as HTMLInputElement;
+    if (
+      radio.type === 'radio' &&
+      radio.name === element.name &&
+      radio.checked
+    ) {
+      return radio.value.trim();
+    }
+  }
+  return '';
 }
 
 /**
@@ -219,8 +245,17 @@ export function validation({ ref, dispatch, config }: ValidationProps): void {
   const resolver = config?.resolver;
   const trackUnvalidatedFields = config?.trackUnvalidatedFields ?? false;
 
+  // Counts distinct names, not elements: a radio group marks `required` on
+  // every member but is one field. Unnamed elements are skipped — they are
+  // never tracked or validated, so counting them yields a denominator no
+  // consumer can satisfy.
   const countRequired = (): number =>
-    Array.from(elements).filter((e) => e?.hasAttribute('required')).length;
+    new Set(
+      Array.from(elements)
+        .filter((e) => e?.hasAttribute('required'))
+        .map((e) => e.getAttribute('name'))
+        .filter((name) => name != null && name !== '')
+    ).size;
 
   // Sync cleanup: dispatch removeField for names that were registered but are no longer in the DOM.
   // This runs on every re-render (React calls the ref callback each render), so it reliably


### PR DESCRIPTION
Closes #83

A radio group is one logical field spread across several elements, and rapid-form treated it as several. That broke two separate things.

## 1. Resolver mode reported the wrong value

`collectFormValues` iterates `form.elements`, so every group member wrote to the same `values[name]` key — the last one in **DOM order** won, whichever was actually checked. With radios `free` / `pro` / `max`, clicking `pro` yielded `'max'`.

Now the group is walked via `element.form` to find its checked member, returning `''` when nothing is selected.

I walk the group rather than querying with a `name`-derived selector (`input[name="${name}"]:checked`). Names come from user markup, and building selector strings from them is the kind of thing that bites later — the codebase already guards hostile names via `UNSAFE_FIELD_NAMES`, so this matches that posture. It also avoids depending on `CSS.escape`.

**Per-field mode was already correct** and is unchanged: its listener reads `e.target`, which is the radio the user just clicked, and clicking a radio is what selects it. Two regression tests cover it.

## 2. `numberOfRequiredFields` counted group members individually

Marking a radio group mandatory means putting `required` on each member — the normal approach — so a three-radio group counted as **3**, inflating the denominator of any "N of M complete" indicator. It now counts distinct names.

## ⚠️ Behavior change

`numberOfRequiredFields` **decreases** for any form containing a required radio group (3 members → 1).

It also no longer counts required elements that have **no `name`**. Those are skipped by `attachFieldListeners`, so they were never tracked or validated — counting them produced a denominator no consumer could ever satisfy. Arguably a second bug fixed by the same change, but it is observable, so flagging it.

Suggest a **minor** with both called out, the way the checkbox change was in `v4.1.0`.

## Tests

6 new tests in `specs/radio-groups.spec.tsx`; **65/65 pass**.

| Test | Pins |
| --- | --- |
| per-field reports selected member | regression (already worked) |
| per-field follows a changed selection | regression (already worked) |
| resolver reports selected, not last in DOM order | fix 1 |
| unselected group reports `''` | fix 1 |
| radio group counts as one field | fix 2 |
| required elements without a name are ignored | fix 2 |

Mutation-checked both independently:

- removing the `radio` branch from `fieldValue` fails exactly the two resolver tests
- reverting `countRequired` to the element count fails exactly the two count tests

The per-field tests survive both mutations by design — that behavior was already correct, and these tests exist to keep it that way.

## Docs

`numberOfRequiredFields` and `Value` rows in `api-reference.mdx` updated: the count is over distinct names, and a radio group is one `values` entry holding the selected member's value.

## Scope

Deliberately excludes `<select multiple>` (#85) — that one needs a public type change and a major. This PR touches no types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)