### PR TITLE
✨ feat!: widen field values to `string | string[]` for multi-value fields

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -56,6 +56,10 @@ export default defineConfig({
             {
               label: 'Migration v2 → v3',
               slug: 'reference/migration-from-v2-to-v3'
+            },
+            {
+              label: 'Migration v4 → v5',
+              slug: 'reference/migration-from-v4-to-v5'
             }
           ]
         }

--- a/packages/docs/src/content/docs/reference/api-reference.mdx
+++ b/packages/docs/src/content/docs/reference/api-reference.mdx
@@ -24,6 +24,17 @@ const { refValidation, values, errors, numberOfRequiredFields } = useRapidForm()
 | `errors` | `Record<string, FieldError>` | Map of validation errors for each field, keyed by the field's `name` attribute. Only fields that have been interacted with appear here. |
 | `numberOfRequiredFields` | `number` | Count of distinct **field names** that carry the `required` attribute in the attached form. A radio group counts once, however many members it has. Required elements without a `name` are not counted, since rapid-form never tracks them. |
 
+:::note[List-valued fields]
+`Value['value']` is `string | string[]`. A `<select multiple>` or `<input type="file" multiple>` reports every selection as a `string[]` — empty selection is `[]`. Every other field type reports a `string`.
+
+```tsx
+values.langs?.value   // ['ts', 'go']  — <select multiple>
+values.email?.value   // 'a@b.com'     — everything else
+```
+
+Narrow with `Array.isArray` or `typeof` before using a value as a string. Migrating from v4? See [Migration v4 → v5](/rapid-form/reference/migration-from-v4-to-v5).
+:::
+
 ---
 
 ## `refValidation(ref, config?)`
@@ -103,7 +114,7 @@ A per-field configuration object supplied as a value inside `Config.validations`
 ```ts
 type ValidationEntry = {
   validation: (props: {
-    value: string
+    value: string | string[]
     formElements: HTMLFormControlsCollection
   }) => boolean
   eventType?: 'input' | 'blur' | 'change'
@@ -115,7 +126,7 @@ type ValidationEntry = {
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `validation` | `(props: { value: string; formElements: HTMLFormControlsCollection }) => boolean` | Yes | Custom validation function. Return `true` when the value is **valid**, `false` when it is invalid. Receives the current field `value` and the full `formElements` collection so you can cross-reference other fields. |
+| `validation` | `(props: { value: string \| string[]; formElements: HTMLFormControlsCollection }) => boolean` | Yes | Custom validation function. Return `true` when the value is **valid**, `false` when it is invalid. Receives the current field `value` and the full `formElements` collection so you can cross-reference other fields. `value` is a `string[]` for list-valued fields — narrow with `Array.isArray` or `typeof` before using it as a string. |
 | `eventType` | `'input' \| 'blur' \| 'change'` | No | Overrides the top-level `eventType` for this specific field only. |
 | `message` | `string` | No | Error message stored in `errors[name].message` when this field's `validation` returns `false`. |
 
@@ -158,7 +169,7 @@ Each entry in the `errors` map conforms to the `FieldError` type.
 ```ts
 type FieldError = {
   name: string
-  value: string
+  value: string | string[]
   isInvalid: boolean
   errorType?: 'invalidFormat'
   message?: string
@@ -170,7 +181,7 @@ type FieldError = {
 | Property | Type | Description |
 |----------|------|-------------|
 | `name` | `string` | The `name` attribute of the form field. |
-| `value` | `string` | The current value of the field at the time the error was recorded. |
+| `value` | `string \| string[]` | The current value of the field at the time the error was recorded. A `string[]` for list-valued fields. |
 | `isInvalid` | `boolean` | `true` when the field fails validation, `false` when it passes. Use this as the primary flag for disabling submit buttons or showing error UI. |
 | `errorType` | `'invalidFormat' \| undefined` | Set to `'invalidFormat'` for built-in format checks (e.g. email format, password length). `undefined` for custom validation errors. |
 | `message` | `string \| undefined` | Human-readable error message. Populated from the `message` property of a `ValidationEntry`, or a built-in default message for format errors. |
@@ -202,7 +213,7 @@ A function type that receives all current form values and returns a map of error
 import type { SchemaResolver } from 'rapid-form'
 
 type SchemaResolver = (
-  values: Record<string, string>
+  values: Record<string, string | string[]>
 ) =>
   | Record<string, string | undefined>
   | Promise<Record<string, string | undefined>>
@@ -225,7 +236,7 @@ import type { Config, Value, FieldError, NumberOfRequiredFields, SchemaResolver 
 | Type | Definition | Description |
 |------|------------|-------------|
 | `Config` | `{ eventType?: EventType; resetOnSubmit?: boolean; validations?: Record<string, ValidationEntry>; resolver?: SchemaResolver; trackUnvalidatedFields?: boolean }` | The optional config parameter accepted by `refValidation`. |
-| `Value` | `{ name: string; value: string }` | Shape of each entry in the `values` map returned by `useRapidForm`. Checkbox fields report their checked state as `'true'` / `'false'`, ignoring any `value` attribute. A radio group is one entry keyed by its shared `name`, holding the selected member's value (`''` when nothing is selected). |
-| `FieldError` | `{ name: string; value: string; isInvalid: boolean; errorType?: 'invalidFormat'; message?: string }` | Shape of each entry in the `errors` map returned by `useRapidForm`. |
+| `Value` | `{ name: string; value: string \| string[] }` | Shape of each entry in the `values` map returned by `useRapidForm`. Checkbox fields report their checked state as `'true'` / `'false'`, ignoring any `value` attribute. A radio group is one entry keyed by its shared `name`, holding the selected member's value (`''` when nothing is selected). List-valued fields — `<select multiple>` and `<input type="file" multiple>` — hold a `string[]`. |
+| `FieldError` | `{ name: string; value: string \| string[]; isInvalid: boolean; errorType?: 'invalidFormat'; message?: string }` | Shape of each entry in the `errors` map returned by `useRapidForm`. |
 | `NumberOfRequiredFields` | `number` | Alias for the `numberOfRequiredFields` return value. |
-| `SchemaResolver` | `(values: Record<string, string>) => Record<string, string \| undefined> \| Promise<...>` | Schema resolver function type. Use with the built-in adapters or write your own. |
+| `SchemaResolver` | `(values: Record<string, string \| string[]>) => Record<string, string \| undefined> \| Promise<...>` | Schema resolver function type. Use with the built-in adapters or write your own. |

--- a/packages/docs/src/content/docs/reference/migration-from-v4-to-v5.mdx
+++ b/packages/docs/src/content/docs/reference/migration-from-v4-to-v5.mdx
@@ -1,0 +1,91 @@
+---
+title: Migration from v4 to v5
+description: A reference page for migrating from Rapid Form v4 to v5.
+---
+
+v5 has a single breaking change: field values can now be a `string[]` as well as a `string`.
+
+This exists so that `<select multiple>` and `<input type="file" multiple>` can report every selection. In v4 they reported only the first, and the rest were unrecoverable.
+
+## What changed
+
+`Value['value']`, `FieldError['value']`, the `value` given to a custom `validation`, and the `values` argument to a `SchemaResolver` all widened from `string` to `string | string[]`.
+
+```diff lang="ts"
+- type Value = { name: string; value: string }
++ type Value = { name: string; value: string | string[] }
+```
+
+Only **list-valued** fields produce an array — a `<select multiple>` or a `<input type="file" multiple>`. Every other field type still produces a `string`, exactly as before. Runtime behaviour for single-value fields is unchanged; what changed is that TypeScript now makes you acknowledge the array case.
+
+## Do you need to change anything?
+
+**No, if** you only read values and pass them somewhere that accepts anything — rendering them in JSX, storing them, comparing them with `===`:
+
+```tsx
+// still fine in v5
+<span>{values.email?.value}</span>
+{values.plan?.value === 'pro' && <ProBadge />}
+```
+
+**Yes, if** you pass a value somewhere that requires a `string`:
+
+```diff lang="tsx"
+- const trimmed = values.email.value.trim()
+- sendToApi(values.email.value)
++ const raw = values.email.value
++ const trimmed = typeof raw === 'string' ? raw.trim() : raw.join(',')
+```
+
+TypeScript will point at every such site, so the compiler is your migration checklist.
+
+## Narrowing inside a custom validation
+
+```diff lang="tsx"
+  refValidation(ref, {
+    validations: {
+      username: {
+-       validation: ({ value }) => value.length > 3,
++       // `length` works on both strings and arrays, so this needs no change
++       validation: ({ value }) => value.length > 3,
+        message: 'Too short',
+      },
+      password: {
+-       validation: ({ value }) => /[0-9]/.test(value),
++       validation: ({ value }) =>
++         typeof value === 'string' && /[0-9]/.test(value),
+        message: 'Needs a digit',
+      },
+    },
+  })
+```
+
+Anything reading `.length` keeps working, since it means "non-empty" for both forms. String-specific methods — `test`, `match`, `toLowerCase`, `trim` — need a `typeof` guard.
+
+## Reading a multi-select
+
+```tsx
+const { refValidation, values } = useRapidForm()
+
+<form ref={(ref) => refValidation(ref)}>
+  <select multiple name="langs" required>
+    <option value="ts">TS</option>
+    <option value="go">Go</option>
+  </select>
+</form>
+
+// values.langs?.value → ['ts', 'go']
+```
+
+An empty selection is `[]`, not `''`, and a required list-valued field is invalid exactly when the list is empty. Resetting the form clears it to `[]`, so the type of a given field's value never changes across a reset.
+
+## Schema resolvers
+
+The bundled Zod and Yup adapters need **no changes** — they pass values straight through to the schema. If you wrote your own resolver and typed its parameter explicitly, widen it:
+
+```diff lang="ts"
+- const resolver = (values: Record<string, string>) => { … }
++ const resolver = (values: Record<string, string | string[]>) => { … }
+```
+
+Your schema should describe multi-selects as arrays, e.g. `z.array(z.string()).min(1)` instead of `z.string()`.

--- a/packages/rapid-form/specs/checkbox-values.spec.tsx
+++ b/packages/rapid-form/specs/checkbox-values.spec.tsx
@@ -85,6 +85,8 @@ describe('checkbox values in per-field mode', () => {
           validations: {
             terms: {
               validation: ({ value }) => {
+                // A checkbox is single-valued; narrow before string use.
+                if (typeof value !== 'string') return false;
                 seen.push(value);
                 return value === 'true';
               },

--- a/packages/rapid-form/specs/multi-value-fields.spec.tsx
+++ b/packages/rapid-form/specs/multi-value-fields.spec.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import { useRapidForm } from '../src/index.js';
+import type { ValidationProps } from '../src/validation.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function MultiSelectForm({ config }: { config?: ValidationProps['config'] }) {
+  const { refValidation, values, errors } = useRapidForm();
+  const v = values.langs?.value;
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref, config);
+      }}
+    >
+      <select multiple title="langs" name="langs" data-testid="langs" required>
+        <option value="ts">TS</option>
+        <option value="js">JS</option>
+        <option value="go">Go</option>
+      </select>
+      <span data-testid="kind">{Array.isArray(v) ? 'array' : typeof v}</span>
+      <span data-testid="json">{JSON.stringify(v ?? null)}</span>
+      <span data-testid="invalid">{String(errors.langs?.isInvalid)}</span>
+      <button data-testid="submit-button" type="submit">
+        Submit
+      </button>
+    </form>
+  );
+}
+
+/** A single-value select, to prove the widening didn't leak into the common case. */
+function SingleSelectForm() {
+  const { refValidation, values } = useRapidForm();
+  const v = values.lang?.value;
+  return (
+    <form
+      ref={(ref) => {
+        refValidation(ref, { resetOnSubmit: false });
+      }}
+    >
+      <select title="lang" name="lang" data-testid="lang" required>
+        <option value="">Pick one</option>
+        <option value="ts">TS</option>
+        <option value="go">Go</option>
+      </select>
+      <span data-testid="kind">{Array.isArray(v) ? 'array' : typeof v}</span>
+      <span data-testid="value">{String(v)}</span>
+    </form>
+  );
+}
+
+// ── specs ────────────────────────────────────────────────────────────────────
+
+describe('<select multiple>', () => {
+  test('captures every selected option, not just the first', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectForm config={{ resetOnSubmit: false }} />);
+    await user.selectOptions(screen.getByTestId('langs'), ['ts', 'go']);
+    expect(screen.getByTestId('kind').textContent).toBe('array');
+    expect(screen.getByTestId('json').textContent).toBe('["ts","go"]');
+  });
+
+  test('reports an empty list when nothing is selected', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectForm config={{ resetOnSubmit: false }} />);
+    const select = screen.getByTestId('langs');
+    await user.selectOptions(select, ['ts']);
+    await user.deselectOptions(select, ['ts']);
+    expect(screen.getByTestId('json').textContent).toBe('[]');
+  });
+
+  test('a required multi-select is invalid only when empty', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectForm config={{ resetOnSubmit: false }} />);
+    const select = screen.getByTestId('langs');
+    await user.selectOptions(select, ['ts']);
+    expect(screen.getByTestId('invalid').textContent).toBe('false');
+    await user.deselectOptions(select, ['ts']);
+    expect(screen.getByTestId('invalid').textContent).toBe('true');
+  });
+
+  test('a resolver receives the full list', async () => {
+    const user = userEvent.setup();
+    const seen: Record<string, string | string[]>[] = [];
+    render(
+      <MultiSelectForm
+        config={{
+          resetOnSubmit: false,
+          resolver: (values) => {
+            seen.push({ ...values });
+            return {};
+          }
+        }}
+      />
+    );
+    await user.selectOptions(screen.getByTestId('langs'), ['ts', 'go']);
+    expect(seen.at(-1)?.langs).toEqual(['ts', 'go']);
+  });
+
+  test('a custom validation receives the full list', async () => {
+    const user = userEvent.setup();
+    const seen: (string | string[])[] = [];
+    render(
+      <MultiSelectForm
+        config={{
+          resetOnSubmit: false,
+          validations: {
+            langs: {
+              validation: ({ value }) => {
+                seen.push(value);
+                return Array.isArray(value) && value.length >= 2;
+              },
+              message: 'Pick at least two'
+            }
+          }
+        }}
+      />
+    );
+    await user.selectOptions(screen.getByTestId('langs'), ['ts']);
+    expect(screen.getByTestId('invalid').textContent).toBe('true');
+    await user.selectOptions(screen.getByTestId('langs'), ['ts', 'go']);
+    expect(screen.getByTestId('invalid').textContent).toBe('false');
+    expect(seen.at(-1)).toEqual(['ts', 'go']);
+  });
+
+  test('resets to an empty list, not an empty string', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectForm />);
+    await user.selectOptions(screen.getByTestId('langs'), ['ts', 'go']);
+    await user.click(screen.getByTestId('submit-button'));
+    // resetOnSubmit defaults to true, so state is cleared on submit.
+    expect(screen.getByTestId('kind').textContent).toBe('array');
+    expect(screen.getByTestId('json').textContent).toBe('[]');
+  });
+});
+
+describe('single-value fields are unaffected', () => {
+  test('a non-multiple select still reports a string', async () => {
+    const user = userEvent.setup();
+    render(<SingleSelectForm />);
+    await user.selectOptions(screen.getByTestId('lang'), 'ts');
+    expect(screen.getByTestId('kind').textContent).toBe('string');
+    expect(screen.getByTestId('value').textContent).toBe('ts');
+  });
+});

--- a/packages/rapid-form/specs/radio-groups.spec.tsx
+++ b/packages/rapid-form/specs/radio-groups.spec.tsx
@@ -55,7 +55,7 @@ describe('radio group values', () => {
 
   test('resolver mode reports the selected member, not the last in DOM order', async () => {
     const user = userEvent.setup();
-    const seen: Record<string, string>[] = [];
+    const seen: Record<string, string | string[]>[] = [];
     render(
       <RadioForm
         config={{
@@ -74,7 +74,7 @@ describe('radio group values', () => {
 
   test('an unselected group reports an empty string', async () => {
     const user = userEvent.setup();
-    const seen: Record<string, string>[] = [];
+    const seen: Record<string, string | string[]>[] = [];
     render(
       <RadioForm
         config={{

--- a/packages/rapid-form/src/reducer.ts
+++ b/packages/rapid-form/src/reducer.ts
@@ -1,11 +1,14 @@
 import type { Reducer } from 'react';
 
 /**
- * Represents a value with a name and a corresponding string value.
+ * Represents a value with a name and a corresponding value.
+ *
+ * `string[]` covers fields that hold a list rather than a single value —
+ * `<select multiple>` and `<input type="file" multiple>`.
  */
 interface Value {
   name: string;
-  value: string;
+  value: string | string[];
 }
 
 /**

--- a/packages/rapid-form/src/validation.ts
+++ b/packages/rapid-form/src/validation.ts
@@ -15,7 +15,7 @@ type EventType = 'change' | 'blur' | 'input';
  * Validation function — return true if the value is valid.
  */
 type ValidationFunction = (props: {
-  value: string;
+  value: string | string[];
   formElements: HTMLFormControlsCollection;
 }) => boolean;
 
@@ -35,7 +35,7 @@ type ValidationConfig = Record<
  * Both sync and async resolvers are supported.
  */
 export type SchemaResolver = (
-  values: Record<string, string>
+  values: Record<string, string | string[]>
 ) =>
   | Record<string, string | undefined>
   | Promise<Record<string, string | undefined>>;
@@ -78,7 +78,7 @@ export interface ValidationProps {
 
 interface InputValidationProps {
   type: HTMLInputElement['type'];
-  value: string;
+  value: string | string[];
   element: HTMLInputElement;
 }
 
@@ -92,10 +92,11 @@ function inputValidation({
       // Use native browser validation — no custom regex, no ReDoS risk.
       return element.validity.valid;
     case 'password':
-      return value.length > 6;
+      return typeof value === 'string' && value.length > 6;
     case 'checkbox':
       return element.checked;
     default:
+      // Correct for both forms: a non-empty string, or a non-empty list.
       return value.length > 0;
   }
 }
@@ -104,10 +105,27 @@ function inputValidation({
  * The state value for a field. Checkboxes report their checked state rather
  * than their `value` attribute, which is `'on'` whether checked or not.
  */
-function fieldValue(element: HTMLInputElement): string {
+function fieldValue(element: HTMLInputElement): string | string[] {
   if (element.type === 'checkbox') return String(element.checked);
   if (element.type === 'radio') return radioGroupValue(element);
+  if (element instanceof HTMLSelectElement) {
+    return element.multiple
+      ? Array.from(element.selectedOptions, (o) => o.value.trim())
+      : element.value.trim();
+  }
+  if (element.type === 'file' && element.multiple) {
+    return Array.from(element.files ?? [], (f) => f.name);
+  }
   return element.value.trim();
+}
+
+/**
+ * Whether a field holds a list rather than a single value. Used to pick the
+ * right empty value when resetting.
+ */
+function isMultiValueField(element: HTMLInputElement): boolean {
+  if (element instanceof HTMLSelectElement) return element.multiple;
+  return element.type === 'file' && element.multiple;
 }
 
 /**
@@ -173,8 +191,8 @@ const UNSAFE_FIELD_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
 /** Collect all named field values from a form's element collection. */
 function collectFormValues(
   elements: HTMLFormControlsCollection
-): Record<string, string> {
-  const values: Record<string, string> = {};
+): Record<string, string | string[]> {
+  const values: Record<string, string | string[]> = {};
   for (const el of Array.from(elements)) {
     const name = el.getAttribute('name');
     if (!name || UNSAFE_FIELD_NAMES.has(name)) continue;
@@ -228,7 +246,11 @@ function resetForm(
   const resetValues: State['values'] = {};
   for (const element of Array.from(elements)) {
     const name = element.getAttribute('name');
-    if (name != null) resetValues[name] = { value: '', name };
+    if (name == null) continue;
+    // A list-valued field resets to an empty list, not an empty string, so the
+    // type of values[name] stays stable across a reset.
+    const empty = isMultiValueField(element as HTMLInputElement) ? [] : '';
+    resetValues[name] = { value: empty, name };
   }
   dispatch?.({
     type: 'reset',


### PR DESCRIPTION
Closes #85

⚠️ **Breaking — needs a major (`v5.0.0`), not a minor.**

## The problem

`<select multiple>` and `<input type="file" multiple>` reported only their **first** selection. Both modes read `element.value`, which on a multi-select returns just the first selected option, so the rest were unrecoverable from `values`.

| Case | Action | v4 | v5 |
| --- | --- | --- | --- |
| `<select multiple>` | select `ts` + `go` | `'ts'` | `['ts', 'go']` |
| nothing selected | — | `''` | `[]` |
| after reset | — | `''` | `[]` |

## Why it breaks

Representing a list needs a list. The alternatives — joining (`'ts,go'`) or JSON-encoding — keep the type as `string` but push parsing onto every consumer and are ambiguous against literal values. #85 has the full trade-off table; this implements the recommended option.

`Value['value']`, `FieldError['value']`, custom `validation`'s `value`, and `SchemaResolver`'s `values` all widen from `string` to `string | string[]`.

**Only list-valued fields produce an array.** Every other field type still produces a string, so runtime behaviour for single-value fields is unchanged — a regression test covers a non-multiple `<select>` still reporting a string. What changed is that TypeScript now makes consumers acknowledge the array case.

## Measured migration cost

The prototype in #85 predicted this; the real implementation confirms it.

- **`src`: 2 internal breaks**, both mechanical (`inputValidation`'s param, `collectFormValues`' return type)
- **Specs — the best available proxy for consumer code: 3 breaks**, all in local type annotations, none in *reading* values
- **Zod and Yup adapters: 0 changes.** They pass values straight to `safeParseAsync(data: unknown)` / `validate(value: unknown)`, so the widening is invisible to them. #85's original claim that they'd be affected was wrong and has been corrected there.

Two things needed no work at all:

- `inputValidation`'s default rule `value.length > 0` already means "non-empty" for both strings and arrays, so a required multi-select validates correctly with no branching. Only `password` needed a `typeof` guard.
- `FieldError` inherits the widening, since `Error extends Value`.

## Also fixed: reset

`resetForm` wrote `value: ''` for every field, which would have left a multi-select as `''` after a reset while being `[]` before it — a field whose value type changes under you. It now resets list-valued fields to `[]`. This was flagged as unresolved in #85's spike; it's fixed here and covered by a test.

## Tests

7 new tests in `specs/multi-value-fields.spec.tsx`; **72/72 pass**.

Covers: every selection captured, empty selection as `[]`, required-only-invalid-when-empty, resolver receiving the list, custom validation receiving the list, reset clearing to `[]`, and a single-value `<select>` still reporting a string.

Mutation-checked both behavioural pieces independently:

- reverting the multi-select branch in `fieldValue` fails 4 tests
- reverting the reset branch fails exactly the reset test

## Docs

- New [Migration v4 → v5](packages/docs/src/content/docs/reference/migration-from-v4-to-v5.mdx) guide, registered in the sidebar — leads with "do you need to change anything?", since most consumers don't
- `api-reference.mdx`: 8 type references updated (`Value`, `FieldError`, `SchemaResolver`, `ValidationEntry.validation`, plus their code blocks), and a note on list-valued fields
- Docs build verified: 18 pages, migration page renders

## Note on `<input type="file" multiple>`

Included deliberately. It has the identical shape of problem and cost **one extra branch** once the widening was done — bundling it avoids spending a second major on it later. It reports file *names*; exposing `File` objects would mean widening further, which I'd rather not do speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)